### PR TITLE
Added PyYAML to deps in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest-cov
     pytest-flakes
     pytest-pep8
-
+    PyYAML
 
 [pytest]
 addopts = --pep8 --flakes --cov-report=term --cov-report=html


### PR DESCRIPTION
The tox is failed because there is no PyYAML at deps of tox.ini.
So I added PyYAML to there.

Signed-off-by: Kouhei Maeda mkouhei@palmtb.net
