### PR TITLE
tox.ini: add {posargs}

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py26,py27,py34
 
 
 [testenv]
-commands = py.test --cov {envsitepackagesdir}/devpi_ldap tests
+commands = py.test --cov {envsitepackagesdir}/devpi_ldap {posargs:tests}
 deps =
     webtest
     mock


### PR DESCRIPTION
Allows passing args to py.test on tox command line. 