### PR TITLE
apply regexpression to group results

### DIFF
--- a/devpi_ldap/main.py
+++ b/devpi_ldap/main.py
@@ -157,7 +157,7 @@ class LDAP(dict):
             config['base'], search_filter,
             search_scope=search_scope, attributes=[attribute_name])
         if found:
-            if not config['regex']: 
+            if 'regex' not in config:
                 return sum((x['attributes'][attribute_name] for x in conn.response), [])
             # otherwise filter out groups by the regex provided
             groupresult = sum((x['attributes'][attribute_name] for x in conn.response), [])


### PR DESCRIPTION
In our environment, the resulting groupname contains complete LDAP information to the group objects. It would be nice to filter that extra information out using a regular expression. This would allow for more meaningful groupnames in devpi.