### PR TITLE
Support user_search on LADP servers which do not include an explicit dn in returned attributes.

### DIFF
--- a/devpi_ldap/main.py
+++ b/devpi_ldap/main.py
@@ -157,9 +157,11 @@ class LDAP(dict):
             search_scope=search_scope, attributes=[attribute_name])
         if found:
             if any(attribute_name in x['attributes'] for x in conn.response):
-                extract_search = lambda s: s['attributes'][attribute_name]
+                def extract_search(s):
+                    return s['attributes'][attribute_name]
             elif attribute_name in ('dn', 'distinguishedName'):
-                extract_search = lambda s: [s[attribute_name]]
+                def extract_search(s):
+                    return [s[attribute_name]]
             else:
                 threadlog.error('configured attribute_name {} not found in any search results'.format(attribute_name))
                 return []

--- a/devpi_ldap/main.py
+++ b/devpi_ldap/main.py
@@ -156,7 +156,15 @@ class LDAP(dict):
             config['base'], search_filter,
             search_scope=search_scope, attributes=[attribute_name])
         if found:
-            return sum((x['attributes'][attribute_name] for x in conn.response), [])
+            if any(attribute_name in x['attributes'] for x in conn.response):
+                extract_search = lambda s: s['attributes'][attribute_name]
+            elif attribute_name in ('dn', 'distinguishedName'):
+                extract_search = lambda s: [s[attribute_name]]
+            else:
+                threadlog.error('configured attribute_name {} not found in any search results'.format(attribute_name))
+                return []
+
+            return sum((extract_search(x) for x in conn.response), [])
         else:
             threadlog.error("Search failed %s %s: %s" % (search_filter, config, conn.result))
             return []


### PR DESCRIPTION
Implement a fallback in user_search which will use a toplevel response attribute instead of object attributes if you are searching on 'dn' or 'distinguishedName' and those do not appear within a returned ldap object.

This happens in our site using redhat directory service, and may be useful for others.