### PR TITLE
Change python3-ldap dependency to python-ldap3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     install_requires=[
         'PyYAML',
         'devpi-server>=2.0.0',
-        'python3-ldap'],
+        'ldap3'],
     include_package_data=True,
     zip_safe=False,
     packages=['devpi_ldap'])


### PR DESCRIPTION
The python3-ldap project has been renamed to python-ldap3 to avoid confusion with the python-ldap library.

See:
* https://pypi.python.org/pypi/python3-ldap/0.9.8.4/
* https://pypi.python.org/pypi/ldap3/0.9.9.3/