### PR TITLE
Allow devpi-ldap command to be invoked using 'python -m devpi-ldap'

### DIFF
--- a/devpi-ldap.py
+++ b/devpi-ldap.py
@@ -1,0 +1,2 @@
+if __name__ == '__main__':
+	__import__('devpi_ldap.main').main.main()

--- a/setup.py
+++ b/setup.py
@@ -54,4 +54,6 @@ setup(
         'ldap3>=0.9.8.6'],
     include_package_data=True,
     zip_safe=False,
-    packages=['devpi_ldap'])
+    packages=['devpi_ldap'],
+    py_modules=['devpi-ldap'],
+)


### PR DESCRIPTION
This simple change enables the devpi-ldap command to be simply invoked as devpi-ldap in addition to via the console script, which may be more difficult to locate or not present.