### PR TITLE
Refactor search conn

### DIFF
--- a/devpi_ldap/main.py
+++ b/devpi_ldap/main.py
@@ -140,11 +140,10 @@ class LDAP(dict):
             config['password'] = '********'
         if conn is None:
             if search_userdn is None:
-                conn = self.connection(self.server())
-            else:
-                conn = self.connection(
-                    self.server(),
-                    userdn=search_userdn, password=search_password)
+                search_password = None
+            conn = self.connection(
+                self.server(),
+                userdn=search_userdn, password=search_password)
             if not self._open_and_bind(conn):
                 threadlog.error("Search failed, couldn't bind user %s %s: %s" % (search_userdn, config, conn.result))
                 return []


### PR DESCRIPTION
These three commits reduce redundant code and attempt to consolidate certain behaviors to make the behavior easier to comprehend, including extracting a method with a docstring to encapsulate the behavior of building a search connection.

The changes are intended to perform the exact same functionality as the previous code. It's probably easier to review the PR by reading the commits in order, as they were broken down into three separate refactors.