### PR TITLE
Fix exception when the attribute_name is dn/distinguishedName and the search fails

### DIFF
--- a/devpi_ldap/main.py
+++ b/devpi_ldap/main.py
@@ -180,7 +180,10 @@ class LDAP(dict):
                         return []
             elif attribute_name in ('dn', 'distinguishedName'):
                 def extract_search(s):
-                    return [s[attribute_name]]
+                    if attribute_name in s:
+                        return [s[attribute_name]]
+                    else:
+                        return []
             else:
                 threadlog.error('configured attribute_name {} not found in any search results'.format(attribute_name))
                 return []


### PR DESCRIPTION
When the search fails to find the user, the search result doesn't necessarily contain `dn`/`distinguishedName`. Trying to get it will cause an exception instead of returning an "unknown" status. This should fix the issue, but note that I'm recalling the fix from memory and I didn't test this.