### PR TITLE
Require ldap3<2.0.0 in setup.py since ldap3>=2.0.0 is incompatible with devpi-ldap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     install_requires=[
         'PyYAML',
         'devpi-server>=2.0.0',
-        'ldap3>=0.9.8.6'],
+        'ldap3>=0.9.8.6,<2.0.0'],
     include_package_data=True,
     zip_safe=False,
     packages=['devpi_ldap'],


### PR DESCRIPTION
`ldap3>=2.0.0` introduced some backwards incompatible changes that don't work with `devpi-ldap`. This should probably be fixed some day and the version requirement changed to require `ldap3>=2.0.0`.