### PR TITLE
Reject empty attributes.

### DIFF
--- a/devpi_ldap/main.py
+++ b/devpi_ldap/main.py
@@ -178,7 +178,7 @@ class LDAP(dict):
             config['base'], search_filter,
             search_scope=search_scope, attributes=[attribute_name])
         if found:
-            if any(attribute_name in x.get('attributes', {}) for x in conn.response):
+            if any(attribute_name in x.get('attributes', {}) and x['attributes'][attribute_name] for x in conn.response):
                 def extract_search(s):
                     if 'attributes' in s:
                         attributes = s['attributes'][attribute_name]


### PR DESCRIPTION
This change addresses the case where an empty value is returned by the LDAP server.

This is an issue specifically when you are attempting to obtain the 'dn' for a user, however an empty 'dn' attribute is being returned by the LDAP server.

Arguably this could be handled in other ways and I'm happy to rewrite if preferred, I'm just not sure there's ever a reason we would want to return from the search function with an empty attribute.